### PR TITLE
Acknowledge Cthulhu heritage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ abcd…
 ```
 
 in red, while avoiding any corruption of any other on-screen display.
+
+`TextWidthLimiter` was initially in [Cthulhu.jl](https://github.com/JuliaDebug/Cthulhu.jl),
+but was redesigned and moved here to allow others to take advantage of it.
+It may be particularly useful for terminal programs where you may want to limit options to a single line.

--- a/src/WidthLimitedIO.jl
+++ b/src/WidthLimitedIO.jl
@@ -83,20 +83,22 @@ end
 
 Base.iswritable(limiter::TextWidthLimiter) = !limiter.isclosed || limiter.seen_esc
 
-"""
-    closewrite(limiter::TextWidthLimiter)
+if isdefined(Base, :closewrite)
+    """
+        closewrite(limiter::TextWidthLimiter)
 
-Turn off further writing to `limiter`. In many cases, `iswritable(limiter)` will now return `false`,
-but it is not an error to attempt to write further values to `limiter`.
+    Turn off further writing to `limiter`. In many cases, `iswritable(limiter)` will now return `false`,
+    but it is not an error to attempt to write further values to `limiter`.
 
-One exception is if ANSI terminal escape codes (e.g., to change text color) had been previously
-written to `limiter`; in that case `iswritable(limiter)` will still return `true`, but henceforth
-the only characters written to `limiter` will be further escape codes. This will ensure, e.g., that
-text color gets reset to its original state.
+    One exception is if ANSI terminal escape codes (e.g., to change text color) had been previously
+    written to `limiter`; in that case `iswritable(limiter)` will still return `true`, but henceforth
+    the only characters written to `limiter` will be further escape codes. This will ensure, e.g., that
+    text color gets reset to its original state.
 
-Thus, it's acceptable to check `iswritable(limiter)` and skip further writing if the return value is `false`.
-"""
-Base.closewrite(limiter::TextWidthLimiter) = limiter.isclosed = true
+    Thus, it's acceptable to check `iswritable(limiter)` and skip further writing if the return value is `false`.
+    """
+    Base.closewrite(limiter::TextWidthLimiter) = limiter.isclosed = true
+end
 
 function Base.take!(limiter::TextWidthLimiter)
     @assert limiter.esc_status ∈ (NONE, FINAL, C0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,11 +75,13 @@ end
     print(limiter, "cde")
     @test !iswritable(limiter)
     take!(limiter)
-    print(limiter, "ab")
-    closewrite(limiter)
-    @test !iswritable(limiter)
-    print(limiter, "cde")
-    @test String(take!(limiter)) == "ab"
+    if isdefined(Base, :closewrite)
+        print(limiter, "ab")
+        closewrite(limiter)
+        @test !iswritable(limiter)
+        print(limiter, "cde")
+        @test String(take!(limiter)) == "ab"
+    end
 
     # ANSI terminal characters
     limiter = TextWidthLimiter(IOBuffer(), 5)


### PR DESCRIPTION
`TextWidthLimiter` was moved here from Cthulhu. It is a near drop-in replacement (a single test will have to be changed, as the test can be argued to be inconsistent). This version is also quite a lot more capable than the original.

I'm going to go ahead and register this, but we have 3 days to complain and yank the registration.

CC @Keno, @simeonschaub, @aviatesk, @vchuravy.
