### PR TITLE
Don't truncate ANSI-escapes by width limit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WidthLimitedIO"
 uuid = "b8c1c048-cf81-46c6-9da0-18c1d99e41f2"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/src/WidthLimitedIO.jl
+++ b/src/WidthLimitedIO.jl
@@ -39,7 +39,8 @@ function Base.write(limiter::TextWidthLimiter, c::Char)
         return n
     end
     cwidth = textwidth(c)   # TODO? Add Preferences to allow users to configure broken terminals, see https://discourse.julialang.org/t/graphemes-vs-chars/96118
-    if limiter.width + cwidth <= limiter.limit - 1   # -1 saves space for '…'
+    in_esc = limiter.esc_status ∈ (ESCAPE1, ESCAPE, INTERMEDIATE, PARAMETER)
+    if limiter.width + cwidth < limiter.limit || in_esc    # < saves space for '…'
         status = limiter.esc_status = ansi_esc_status(limiter.esc_status, c)
         if status != NONE
             limiter.seen_esc = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,17 @@ end
     printstyled(IOContext(limiter, :color=>true), "abcdef"; color=:red)
     @test iswritable(limiter)    # because seen_esc == true
     @test String(take!(limiter)) == "\e[31mabcd…\e[39m"
+    # Placement of escape initiation relative to width is robust
+    print(limiter, "1\e[31m23456\e[39m")
+    @test String(take!(limiter)) == "1\e[31m234…\e[39m"
+    print(limiter, "12\e[31m3456\e[39m")
+    @test String(take!(limiter)) == "12\e[31m34…\e[39m"
+    print(limiter, "123\e[31m456\e[39m")
+    @test String(take!(limiter)) == "123\e[31m4…\e[39m"
+    print(limiter, "1234\e[31m56\e[39m")
+    @test String(take!(limiter)) == "1234\e[31m…\e[39m"
+    print(limiter, "12345\e[31m6\e[39m")
+    @test String(take!(limiter)) == "1234…"
 
     # Malformed ANSI characters
     limiter = TextWidthLimiter(IOBuffer(), 5)


### PR DESCRIPTION
Formerly, if we hit the limit wihin an extended escape sequence,
we stopped updating the status and thus would error on receipt of
a subsequent escape-character.